### PR TITLE
Drop repo-sync/pull-request in favor of gh

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -62,15 +62,19 @@ jobs:
         run: git push origin "prepare-release-${{ github.event.inputs.version }}"
 
       - name: Create pull request
-        uses: repo-sync/pull-request@v2
-        with:
-          # We need to use a bot token to be able to trigger workflows that listen to pull_request calls
-          github_token: ${{ steps.generate_token.outputs.token }}
-          source_branch: prepare-release-${{ github.event.inputs.version }}
-          destination_branch: main
-          pr_assignee: ${{ github.event.sender.login }}
-          pr_title: Prepare for release of ${{ github.event.inputs.version }}
-          pr_label: "t: release"
-          pr_body: |
-            Release preparation triggered by @${{ github.event.sender.login }}.
-            Once the pull request is merged, you can trigger a PyPI release by pushing a \`v${{ github.event.inputs.version }}\` git tag in the repository.
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          VERSION: ${{ github.event.inputs.version }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          echo "Release preparation triggered by $SENDER." > pr-body.txt
+          echo "Once the pull request is merged, you can trigger a PyPI release by pushing a \`v$VERSION\` git tag in the repository." >> pr-body.txt
+
+          gh pr create \
+            --title "Prepare for release of $VERSION" \
+            --body-file pr-body.txt \
+            --label "t: release" \
+            --assignee "$SENDER"
+
+          PR_NUMBER="$(gh pr view --json number -q .number)"
+          echo "PR #$PR_NUMBER opened"

--- a/.github/workflows/update-minecraft-data.yml
+++ b/.github/workflows/update-minecraft-data.yml
@@ -92,19 +92,22 @@ jobs:
       - name: Create pull request
         id: create_pr
         if: steps.update.outputs.should_continue == 'true'
-        uses: repo-sync/pull-request@v2
-        with:
-          # We need to use a bot token to be able to trigger workflows that listen to pull_request calls
-          github_token: ${{ steps.generate_token.outputs.token }}
-          source_branch: update-mcdata-${{ steps.version_check.outputs.latest_tag }}
-          destination_branch: main
-          pr_title: Update submodule to minecraft-data ${{ steps.version_check.outputs.latest_tag }}
-          pr_label: "a: dependencies"
-          pr_body: |
-            Bumps minecraft-data repository to the latest release: ${{ steps.version_check.outputs.latest_tag }}
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          LATEST_TAG: ${{ steps.version_check.outputs.latest_tag }}
+        run: |
+          echo "Bumps minecraft-data repository to the latest release: $LATEST_TAG" > pr-body.txt
+          echo "" >> pr-body.txt
+          echo "Once the pull request is merged, it might be a good idea to consider making a new release, to make this minecraft-data repository accessible to the users." >> pr-body.txt
 
-            Once the pull request is merged, it might be a good idea to consider making a new release, to make
-            this minecraft-data repository accessible to the users.
+          gh pr create \
+            --title "Update submodule to minecraft-data $LATEST_TAG" \
+            --body-file pr-body.txt \
+            --label "a: dependencies"
+
+          PR_NUMBER="$(gh pr view --json number -q .number)"
+          echo "PR #$PR_NUMBER opened"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Setup uv
         if: steps.update.outputs.should_continue == 'true'

--- a/changes/18.internal.md
+++ b/changes/18.internal.md
@@ -1,0 +1,1 @@
+Drop [repo-sync/pull-request](https://github.com/repo-sync/pull-request) action in favor of GitHub CLI


### PR DESCRIPTION

The [repo-sync/pull-request](https://github.com/repo-sync/pull-request) action has been archived, as it's now possible to simply use the GitHub CLI tool for creating pull requests. This PR replaces uses of this action with the `gh pr create` command.
