### PR TITLE
Parametrize (edition, version) tests with metafunc

### DIFF
--- a/changes/24.internal.md
+++ b/changes/24.internal.md
@@ -1,0 +1,1 @@
+Automatically parametrize all tests that have both the `edition` and the `version` parameters over all edition,versions pairs through pytest metafunc.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from minebase import Edition, _load_data_paths  # pyright: ignore[reportPrivateUsage]
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Dynamically generate pytest parameter sets for tests requesting 'edition' and 'version' fixtures.
+
+    This hook loads the data paths manifest using `_load_data_paths()` and extracts all available
+    versions for both Edition.PC and Edition.BEDROCK. It then parametrizes tests with every
+    (edition, version) pair, so each combination runs as a separate test case.
+
+    If loading the manifest fails or no versions are found for a given edition, the test
+    collection will be skipped with an appropriate message.
+    """
+    if {"edition", "version"} <= set(metafunc.fixturenames):  # subset check
+        try:
+            manifest = _load_data_paths()
+        except Exception as exc:  # noqa: BLE001
+            pytest.skip(f"Could not load data paths manifest: {exc}")
+
+        params: list[tuple[Edition, str]] = []
+        for edition in Edition.__members__.values():
+            versions = manifest[edition.value]
+            if not versions:
+                pytest.skip(f"No versions found for edition {edition}")
+            params.extend((edition, version) for version in versions)
+
+        metafunc.parametrize(
+            ("edition", "version"),
+            params,
+            ids=[f"{edition.name}-{version}" for edition, version in params],
+        )

--- a/tests/minebase/test_integration.py
+++ b/tests/minebase/test_integration.py
@@ -9,7 +9,6 @@ import pytest
 
 from minebase import (
     Edition,
-    _load_data_paths,  # pyright: ignore[reportPrivateUsage]
     _validate_data,  # pyright: ignore[reportPrivateUsage]
     load_common_data,
     load_version,
@@ -29,25 +28,7 @@ def test_load_common_data_for_each_edition(edition: Edition) -> None:
     assert data, f"No common data found for edition {edition}"
 
 
-@pytest.mark.parametrize("edition", Edition.__members__.values())
-def test_all_versions_loadable(edition: Edition) -> None:
-    """Iterate over every version defined in dataPaths.json and ensure it loads."""
-    manifest = _load_data_paths()
-    if edition.value not in manifest:
-        pytest.skip(f"Edition {edition.value} not present in dataPaths.json")
-
-    versions = manifest[edition.value]
-    assert versions, f"No versions listed for edition {edition}"
-
-    failed_versions: list[tuple[str, Exception]] = []
-
-    for version in versions:
-        try:
-            result = load_version(version, edition)
-            assert isinstance(result, dict)
-        except Exception as exc:  # noqa: PERF203,BLE001
-            failed_versions.append((version, exc))
-
-    if failed_versions:
-        fails = "\n".join(f"{v}: {err}" for v, err in failed_versions)
-        pytest.fail(f"{len(failed_versions)} version(s) failed to load for {edition.name}:\n{fails}")
+def test_all_versions_loadable(edition: Edition, version: str) -> None:  # parametrized from conftest
+    """Ensure that a specific version for an edition can be loaded."""
+    result = load_version(version, edition)
+    assert isinstance(result, dict)


### PR DESCRIPTION
This uses `pytest_generate_tests` hook to parametrize test functions that have both an `edition` and `version` fixtures (parameres) by loading all supported versions from the manifest. If manifest loading fails, those tests will be skipped (manifest loading should be tested separately).

This is a better approach than the earlier one which just tested all versions for a single edition in a single test case.